### PR TITLE
fix: 🐞 skip inline assets if already inlined

### DIFF
--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -164,6 +164,7 @@ async function toBase64(
   config: ResolvedUserConfig
 ): Promise<string> {
   if (pathname === '') return ''
+  if (pathname.startsWith('data:image/png;base64,')) return pathname
 
   const absolutePath = path.join(process.cwd(), config.baseDir, pathname)
   try {


### PR DESCRIPTION
There will be a potential bug if this [pull request](https://github.com/uktrade/cypress-image-diff/pull/216) is merged, that is if an url is already a dataUrl, then the function `toBase64` should return as is.